### PR TITLE
Find and fix bug in codebase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,62 +45,38 @@ async fn run_monitor(
                 }
             }
             _ = async {
-                let mut state_guard = state.lock().await;
+                let polling_interval = {
+                    let mut state_guard = state.lock().await;
 
-                // Skip monitoring if not connected
-                if !state_guard.is_connected {
-                    sleep(Duration::from_secs(state_guard.config.webreg.polling_interval)).await;
-                    return;
-                }
-
-                // Clone all the values we need
-                let term = state_guard.term.clone();
-                let wrapper = state_guard.clone_wrapper();
-                let notifier = state_guard.notifier.clone();
-                let chem_config = state_guard.config.courses.chem.clone();
-                let bild_config = state_guard.config.courses.bild.clone();
-                let polling_interval = state_guard.config.webreg.polling_interval;
-                let seat_threshold = state_guard.config.monitoring.seat_threshold;
-
-                // Monitor CHEM sections
-                let chem_sections = match &chem_config {
-                    CourseDetails::New(details) => details.sections.clone(),
-                    CourseDetails::Legacy(details) => to_section_groups(details),
-                };
-
-                for section_group in &chem_sections {
-                // Monitor lecture section
-                if let Ok(Some(section_id)) = monitor_section_with_retry(
-                    &wrapper,
-                    &term,
-                    &section_group.lecture,
-                    &chem_config.department(),
-                    &chem_config.course_code(),
-                    polling_interval,
-                    seat_threshold,
-                    &notifier,
-                ).await {
-                    state_guard.stats.enrollment_attempts += 1;
-                    if let Ok(true) = try_enroll_with_retry(
-                        &wrapper,
-                        &term,
-                        &section_id,
-                        &chem_config.department(),
-                        &chem_config.course_code(),
-                        &section_group.lecture,
-                        &notifier,
-                        &mut state_guard.stats,
-                    ).await {
-                        state_guard.stats.successful_enrollments += 1;
+                    // Skip monitoring if not connected
+                    if !state_guard.is_connected {
+                        let interval = state_guard.config.webreg.polling_interval;
+                        drop(state_guard); // Release lock before sleeping
+                        sleep(Duration::from_secs(interval)).await;
+                        return;
                     }
-                }
 
-                // Monitor discussion sections
-                for discussion in &section_group.discussions {
+                    // Clone all the values we need
+                    let term = state_guard.term.clone();
+                    let wrapper = state_guard.clone_wrapper();
+                    let notifier = state_guard.notifier.clone();
+                    let chem_config = state_guard.config.courses.chem.clone();
+                    let bild_config = state_guard.config.courses.bild.clone();
+                    let polling_interval = state_guard.config.webreg.polling_interval;
+                    let seat_threshold = state_guard.config.monitoring.seat_threshold;
+
+                    // Monitor CHEM sections
+                    let chem_sections = match &chem_config {
+                        CourseDetails::New(details) => details.sections.clone(),
+                        CourseDetails::Legacy(details) => to_section_groups(details),
+                    };
+
+                    for section_group in &chem_sections {
+                    // Monitor lecture section
                     if let Ok(Some(section_id)) = monitor_section_with_retry(
                         &wrapper,
                         &term,
-                        discussion,
+                        &section_group.lecture,
                         &chem_config.department(),
                         &chem_config.course_code(),
                         polling_interval,
@@ -114,52 +90,52 @@ async fn run_monitor(
                             &section_id,
                             &chem_config.department(),
                             &chem_config.course_code(),
-                            discussion,
+                            &section_group.lecture,
                             &notifier,
                             &mut state_guard.stats,
                         ).await {
                             state_guard.stats.successful_enrollments += 1;
                         }
                     }
-                }
-            }
 
-            // Monitor BILD sections
-            let bild_sections = to_section_groups(&bild_config);
-
-            for section_group in &bild_sections {
-                // Monitor lecture section
-                if let Ok(Some(section_id)) = monitor_section_with_retry(
-                    &wrapper,
-                    &term,
-                    &section_group.lecture,
-                    &bild_config.department,
-                    &bild_config.course_code,
-                    polling_interval,
-                    seat_threshold,
-                    &notifier,
-                ).await {
-                    state_guard.stats.enrollment_attempts += 1;
-                    if let Ok(true) = try_enroll_with_retry(
-                        &wrapper,
-                        &term,
-                        &section_id,
-                        &bild_config.department,
-                        &bild_config.course_code,
-                        &section_group.lecture,
-                        &notifier,
-                        &mut state_guard.stats,
-                    ).await {
-                        state_guard.stats.successful_enrollments += 1;
+                    // Monitor discussion sections
+                    for discussion in &section_group.discussions {
+                        if let Ok(Some(section_id)) = monitor_section_with_retry(
+                            &wrapper,
+                            &term,
+                            discussion,
+                            &chem_config.department(),
+                            &chem_config.course_code(),
+                            polling_interval,
+                            seat_threshold,
+                            &notifier,
+                        ).await {
+                            state_guard.stats.enrollment_attempts += 1;
+                            if let Ok(true) = try_enroll_with_retry(
+                                &wrapper,
+                                &term,
+                                &section_id,
+                                &chem_config.department(),
+                                &chem_config.course_code(),
+                                discussion,
+                                &notifier,
+                                &mut state_guard.stats,
+                            ).await {
+                                state_guard.stats.successful_enrollments += 1;
+                            }
+                        }
                     }
                 }
 
-                // Monitor discussion sections
-                for discussion in &section_group.discussions {
+                // Monitor BILD sections
+                let bild_sections = to_section_groups(&bild_config);
+
+                for section_group in &bild_sections {
+                    // Monitor lecture section
                     if let Ok(Some(section_id)) = monitor_section_with_retry(
                         &wrapper,
                         &term,
-                        discussion,
+                        &section_group.lecture,
                         &bild_config.department,
                         &bild_config.course_code,
                         polling_interval,
@@ -173,20 +149,51 @@ async fn run_monitor(
                             &section_id,
                             &bild_config.department,
                             &bild_config.course_code,
-                            discussion,
+                            &section_group.lecture,
                             &notifier,
                             &mut state_guard.stats,
                         ).await {
                             state_guard.stats.successful_enrollments += 1;
                         }
                     }
+
+                    // Monitor discussion sections
+                    for discussion in &section_group.discussions {
+                        if let Ok(Some(section_id)) = monitor_section_with_retry(
+                            &wrapper,
+                            &term,
+                            discussion,
+                            &bild_config.department,
+                            &bild_config.course_code,
+                            polling_interval,
+                            seat_threshold,
+                            &notifier,
+                        ).await {
+                            state_guard.stats.enrollment_attempts += 1;
+                            if let Ok(true) = try_enroll_with_retry(
+                                &wrapper,
+                                &term,
+                                &section_id,
+                                &bild_config.department,
+                                &bild_config.course_code,
+                                discussion,
+                                &notifier,
+                                &mut state_guard.stats,
+                            ).await {
+                                state_guard.stats.successful_enrollments += 1;
+                            }
+                        }
+                    }
                 }
-            }
 
-                let health = state_guard.check_health().await;
-                info!("Health status: {:?}", health);
-                state_guard.last_check_time = Local::now().to_string();
+                    let health = state_guard.check_health().await;
+                    info!("Health status: {:?}", health);
+                    state_guard.last_check_time = Local::now().to_string();
 
+                    polling_interval
+                }; // Lock is released here
+
+                // Sleep without holding the lock
                 sleep(Duration::from_secs(polling_interval)).await;
             } => {}
         }


### PR DESCRIPTION
The monitoring loop was holding the AppState mutex lock during the sleep period at the end of each polling cycle. This caused:

- Mutex held for entire polling interval (30+ seconds typically)
- Blocked cookie refresh timer from accessing state
- Potential deadlocks and performance degradation

Fixed by wrapping the monitoring logic in a block that releases the lock before sleeping. The polling_interval is now returned from the block and used for sleeping without holding the lock.

This improves concurrency and prevents unnecessary lock contention.