### PR TITLE
Find and fix a bug in codebase

### DIFF
--- a/src/job_manager.rs
+++ b/src/job_manager.rs
@@ -231,6 +231,9 @@ impl JobManager {
                         info!("Health status: {:?}", health);
                         state_guard.last_check_time = Local::now().to_string();
 
+                        // Release lock before sleeping to allow cookie refresh and API calls
+                        drop(state_guard);
+
                         sleep(Duration::from_secs(polling_interval)).await;
                     } => {}
                 }


### PR DESCRIPTION
The monitoring loop was holding the AppState mutex lock during the sleep call at the end of each iteration, blocking other operations like cookie refresh and API calls for 30+ seconds per cycle.

This bug was already fixed in main.rs (commit d898889) but remained in job_manager.rs. Added explicit drop(state_guard) before sleep to release the lock and prevent deadlock conditions.

Fixes potential deadlock and performance issues in the monitoring loop.