### PR TITLE
Find and fix bug or improve types

### DIFF
--- a/src/job_manager.rs
+++ b/src/job_manager.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use std::time::Duration;
 use tokio::time::sleep;
-use log::info;
+use log::{info, error};
 use chrono::Local;
 
 use crate::state::AppState;
@@ -83,7 +83,16 @@ impl JobManager {
 
                         // Clone all the values we need
                         let term = state_guard.term.clone();
-                        let wrapper = state_guard.clone_wrapper();
+                        let polling_interval_val = state_guard.config.webreg.polling_interval;
+                        let wrapper = match state_guard.clone_wrapper() {
+                            Ok(w) => w,
+                            Err(e) => {
+                                error!("Failed to clone WebRegWrapper: {:?}", e);
+                                drop(state_guard);
+                                sleep(Duration::from_secs(polling_interval_val)).await;
+                                return;
+                            }
+                        };
                         let notifier = state_guard.notifier.clone();
                         let chem_config = state_guard.config.courses.chem.clone();
                         let bild_config = state_guard.config.courses.bild.clone();


### PR DESCRIPTION
Fixed several critical bugs that could cause panics:

1. notifier.rs:
   - Replaced unwrap() with proper error handling for email parsing
   - Added error handling for SMTP relay creation
   - Now gracefully handles invalid email addresses

2. state.rs:
   - Changed clone_wrapper() to return Result instead of panicking
   - Added error handling for stats serialization
   - Replaced expect() with proper error propagation

3. main.rs & job_manager.rs:
   - Updated clone_wrapper() call sites to handle Result
   - Added proper error logging for wrapper cloning failures
   - Ensures monitoring continues even if wrapper clone fails

These changes eliminate panic-prone unwrap/expect calls and make the application more robust when handling invalid configuration or runtime errors.