### PR TITLE
Find and fix bug or improve types

### DIFF
--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -17,16 +17,14 @@ pub async fn try_enroll(
         .try_build()
         .ok_or("Failed to build enrollment request")?;
 
-    match wrapper.req(term).parsed().add_section(AddType::Enroll, enroll_request, true).await {
-        Ok(result) => {
-            info!("Enrollment attempt result: {:?}", result);
-            Ok(result)
-        },
-        Err(e) => {
+    let result = wrapper.req(term).parsed().add_section(AddType::Enroll, enroll_request, true).await
+        .map_err(|e| {
             error!("Enrollment error: {:?}", e);
-            Ok(false)
-        }
-    }
+            e
+        })?;
+
+    info!("Enrollment attempt result: {:?}", result);
+    Ok(result)
 }
 
 pub async fn try_enroll_with_retry(


### PR DESCRIPTION
Previously, the try_enroll function was converting all errors to Ok(false), making it impossible for callers to distinguish between:
- Legitimate enrollment failures (seat taken)
- Network errors that should be retried
- Authentication failures requiring user intervention

This broke the retry logic in try_enroll_with_retry, as errors were swallowed before the retry mechanism could handle them.

The fix properly propagates errors using the ? operator while still logging them for debugging purposes.